### PR TITLE
Fixed Linux compilation issue

### DIFF
--- a/Sources/LiquidLocalDriver/LiquidLocalStorage.swift
+++ b/Sources/LiquidLocalDriver/LiquidLocalStorage.swift
@@ -12,9 +12,9 @@ struct LiquidLocalStorage: FileStorage {
     let fileio: NonBlockingFileIO
     let configuration: LiquidLocalStorageConfiguration
     let context: FileStorageContext
-    let posixMode: UInt16
+    let posixMode: mode_t
     
-    init(fileio: NonBlockingFileIO, configuration: LiquidLocalStorageConfiguration, context: FileStorageContext, posixMode: UInt16 = 0o744) {
+    init(fileio: NonBlockingFileIO, configuration: LiquidLocalStorageConfiguration, context: FileStorageContext, posixMode: mode_t = 0o744) {
         self.fileio = fileio
         self.configuration = configuration
         self.context = context


### PR DESCRIPTION
Hello,

there is a bug with the linux compilation. 

This will correct the bug and doesn't affect anything else.

Thanks,

Denis

/.build/checkouts/liquid-local-driver/Sources/LiquidLocalDriver/LiquidLocalStorage.swift:51:107: error: cannot convert value of type 'UInt16' to expected argument type 'mode_t' (aka 'UInt32')
            return fileio.openFile(path: fileUrl.path, mode: .write, flags: .allowFileCreation(posixMode: posixMode), eventLoop: context.eventLoop)
                                                                                                          ^
                                                                                                          mode_t(  )